### PR TITLE
Add the ability to toggle the menu bar on non-OS X platforms.

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,10 +2,13 @@
 
 var App = require('app');
 var BrowserWindow = require('browser-window');
+var ConfigStore = require('configstore');
 var Menu = require('menu');
 var Shell = require('shell');
 
 require('crash-reporter').start();
+
+var conf = new ConfigStore('IRCCloud');
 
 App.once('ready', function() {
   var template;

--- a/main.js
+++ b/main.js
@@ -277,6 +277,13 @@ App.once('ready', function() {
             }
           },
           {
+            label: 'Toggle &Menu Bar',
+            accelerator: 'Ctrl+Shift+M',
+            click: function() {
+              App.emit('toggle-menu-bar');
+            }
+          },
+          {
             label: 'Toggle &Developer Tools',
             accelerator: 'Alt+Ctrl+I',
             click: function() {
@@ -320,6 +327,16 @@ App.on('window-all-closed', function () {
   }
 });
 
+function hideMenuBar(window) {
+  window.setAutoHideMenuBar(true);
+  window.setMenuBarVisibility(false);
+}
+
+function showMenuBar(window) {
+  window.setAutoHideMenuBar(false);
+  window.setMenuBarVisibility(true);
+}
+
 function openMainWindow() {
   mainWindow = new BrowserWindow({
     width: 920,
@@ -345,6 +362,10 @@ function openMainWindow() {
     event.preventDefault();
     Shell.openExternal(url);
   });
+
+  if (conf.get('menu-bar') === false) {
+    hideMenuBar(mainWindow);
+  }
 }
 
 App.on('activate-with-no-open-windows', function () {
@@ -353,4 +374,14 @@ App.on('activate-with-no-open-windows', function () {
 
 App.on('ready', function () {
   openMainWindow();
+});
+
+App.on('toggle-menu-bar', function () {
+  if (mainWindow.isMenuBarAutoHide()) {
+    showMenuBar(mainWindow);
+    conf.set('menu-bar', true);
+  } else {
+    hideMenuBar(mainWindow);
+    conf.set('menu-bar', false);
+  }
 });

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test": "rm -rf dist; mkdir dist; ./build-all $npm_package_name $npm_package_version"
   },
   "devDependencies": {
+    "configstore": "^1.4.0",
     "electron-packager": "^5.2.0",
     "electron-prebuilt": "^0.36.2",
     "grunt-electron": "^2.0.1"


### PR DESCRIPTION
This adds a dependency on the configstore package to persist the setting.
