### PR TITLE
Zoom factor save

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@ var BrowserWindow = require('browser-window');
 var ConfigStore = require('configstore');
 var Menu = require('menu');
 var Shell = require('shell');
-var IPC = require('electron').ipcMain;
+var IpcMain = require('electron').ipcMain;
 
 require('crash-reporter').start();
 
@@ -409,6 +409,6 @@ App.on('toggle-menu-bar', function () {
   }
 });
 
-IPC.on('zoom-factor-changed', function(event, zoom) {
+IpcMain.on('zoom-factor-changed', function (event, zoom) {
   conf.set({ zoom_factor: zoom });
 });

--- a/main.js
+++ b/main.js
@@ -5,6 +5,7 @@ var BrowserWindow = require('browser-window');
 var ConfigStore = require('configstore');
 var Menu = require('menu');
 var Shell = require('shell');
+var IPC = require('electron').ipcMain;
 
 require('crash-reporter').start();
 
@@ -341,12 +342,13 @@ function openMainWindow() {
   mainWindow = new BrowserWindow({
     width: conf.get('width') || 920,
     height: conf.get('height') || 700,
+    webPreferences: { zoomFactor: conf.get('zoom_factor') || 1.0 },
     preload: __dirname + '/webframe.js',
     icon: __dirname + 'resources/icon.iconset/icon_512x512.png',
     title: 'IRCCloud'
   });
 
-  mainWindow.loadUrl('https://www.irccloud.com');
+  mainWindow.loadURL('https://www.irccloud.com');
 
   mainWindow.on('closed', function () {
     mainWindow = null;
@@ -405,4 +407,8 @@ App.on('toggle-menu-bar', function () {
     hideMenuBar(mainWindow);
     conf.set('menu-bar', false);
   }
+});
+
+IPC.on('zoom-factor-changed', function(event, zoom) {
+  conf.set({ zoom_factor: zoom });
 });

--- a/webframe.js
+++ b/webframe.js
@@ -1,4 +1,18 @@
 var webFrame = require('web-frame');
+var ipc = require("ipc");
+
+(function() {
+  var webFrameSetZoomFactor = webFrame.setZoomFactor;
+  webFrame.setZoomFactor = function () {
+    var oldZoom = webFrame.getZoomFactor();
+    var ret = webFrameSetZoomFactor.apply(this, arguments);
+
+    if (oldZoom != webFrame.getZoomFactor())
+      ipc.send("zoom-factor-changed", webFrame.getZoomFactor());
+
+    return ret;
+  };
+})();
 
 window._zoomIn = function () {
   webFrame.setZoomFactor(webFrame.getZoomFactor() + 0.1);

--- a/webframe.js
+++ b/webframe.js
@@ -1,15 +1,14 @@
 var webFrame = require('web-frame');
-var ipc = require("ipc");
+var ipcRenderer = require('electron').ipcRenderer;
 
 (function() {
   var webFrameSetZoomFactor = webFrame.setZoomFactor;
   webFrame.setZoomFactor = function () {
     var oldZoom = webFrame.getZoomFactor();
     var ret = webFrameSetZoomFactor.apply(this, arguments);
-
-    if (oldZoom != webFrame.getZoomFactor())
-      ipc.send("zoom-factor-changed", webFrame.getZoomFactor());
-
+    if (oldZoom != webFrame.getZoomFactor()) {
+      ipcRenderer.send('zoom-factor-changed', webFrame.getZoomFactor());
+    }
     return ret;
   };
 })();


### PR DESCRIPTION
webframe: override setZoomFactor and emit a zoom-factor-changed IPC when called

When the webFrame zoom factor changes we need to get notified, so let's override the setter function.
Once the app receives this event we update the configuration accordingly.
