### PR TITLE
webframe: add context menu on links to open or copy their location

### DIFF
--- a/webframe.js
+++ b/webframe.js
@@ -11,3 +11,31 @@ window._zoomOut = function () {
 window._zoomActualSize = function() {
   webFrame.setZoomFactor(1);
 };
+
+var remote = require('remote');
+var Menu = remote.require('menu');
+var MenuItem = remote.require('menu-item');
+var linkMenu = new Menu();
+
+linkMenu.append(new MenuItem({
+  label: 'Open Link',
+  accelerator: 'CommandOrControl+O',
+  click: function (evt) {
+    window.open(document.activeElement.href);
+  }
+}));
+
+linkMenu.append(new MenuItem({
+  label: 'Copy Link',
+  accelerator: 'CommandOrControl+C',
+  click: function (evt) {
+    require('electron').clipboard.writeText(document.activeElement.href);
+  }
+}));
+
+window.addEventListener('contextmenu', function (event) {
+  if (document.activeElement.tagName == 'A' && document.activeElement.href.length > 0) {
+    event.preventDefault();
+    linkMenu.popup(remote.getCurrentWindow());
+  }
+}, false);


### PR DESCRIPTION
Add Context menu on links with two elements, Open and Copy to Clipboard.
