### PR TITLE
Actions menu shortcuts

### DIFF
--- a/main.js
+++ b/main.js
@@ -374,6 +374,19 @@ App.once('ready', function() {
             focusedWindow.webContents.executeJavaScript('_moveNextUnreadChannel()');
           }
         }
+      },
+      {
+        type: 'separator'
+      },
+      {
+        label: 'Switch to Previously Selected Channel',
+        accelerator: 'CommandOrControl+Tab',
+        click: function() {
+          var focusedWindow = BrowserWindow.getFocusedWindow();
+          if (focusedWindow && focusedWindow.webContents) {
+            focusedWindow.webContents.executeJavaScript('_movePreviouslySelectedChannel()');
+          }
+        }
       }
     ]
   });

--- a/main.js
+++ b/main.js
@@ -5,7 +5,6 @@ var BrowserWindow = require('browser-window');
 var ConfigStore = require('configstore');
 var Menu = require('menu');
 var Shell = require('shell');
-var GlobalShortcut = require('electron').globalShortcut;
 
 require('crash-reporter').start();
 
@@ -316,6 +315,69 @@ App.once('ready', function() {
     ];
   }
 
+  // Add actions as 2nd menu item
+  template.splice(1, 0, {
+    label: 'Actions',
+    submenu: [
+      {
+        label: 'Jump to Channel',
+        accelerator: 'CommandOrControl+P',
+        click: function() {
+          var focusedWindow = BrowserWindow.getFocusedWindow();
+          if (focusedWindow && focusedWindow.webContents) {
+            focusedWindow.webContents.executeJavaScript('_openChannelPalette()');
+          }
+        }
+      },
+      {
+        type: 'separator'
+      },
+      {
+        label: 'Switch to Previous Channel',
+        accelerator: 'CommandOrControl+PageUp',
+        click: function() {
+          var focusedWindow = BrowserWindow.getFocusedWindow();
+          if (focusedWindow && focusedWindow.webContents) {
+            focusedWindow.webContents.executeJavaScript('_movePrevChannel()');
+          }
+        }
+      },
+      {
+        label: 'Switch to Next Channel',
+        accelerator: 'CommandOrControl+PageDown',
+        click: function() {
+          var focusedWindow = BrowserWindow.getFocusedWindow();
+          if (focusedWindow && focusedWindow.webContents) {
+            focusedWindow.webContents.executeJavaScript('_moveNextChannel()');
+          }
+        }
+      },
+      {
+        type: 'separator'
+      },
+      {
+        label: 'Switch to Previous Unread Channel',
+        accelerator: 'CommandOrControl+Shift+PageUp',
+        click: function() {
+          var focusedWindow = BrowserWindow.getFocusedWindow();
+          if (focusedWindow && focusedWindow.webContents) {
+            focusedWindow.webContents.executeJavaScript('_movePrevUnreadChannel()');
+          }
+        }
+      },
+      {
+        label: 'Switch to Next Unread Channel',
+        accelerator: 'CommandOrControl+Shift+PageDown',
+        click: function() {
+          var focusedWindow = BrowserWindow.getFocusedWindow();
+          if (focusedWindow && focusedWindow.webContents) {
+            focusedWindow.webContents.executeJavaScript('_moveNextUnreadChannel()');
+          }
+        }
+      }
+    ]
+  });
+
   var menu = Menu.buildFromTemplate(template);
   Menu.setApplicationMenu(menu);
 });
@@ -388,41 +450,6 @@ function openMainWindow() {
   if (conf.get('menu-bar') === false) {
     hideMenuBar(mainWindow);
   }
-
-  GlobalShortcut.register('Ctrl+P', function() {
-    var focusedWindow = BrowserWindow.getFocusedWindow();
-    if (focusedWindow && focusedWindow.webContents) {
-      focusedWindow.webContents.executeJavaScript('_openChannelPalette()');
-    }
-  });
-
-  GlobalShortcut.register('Ctrl+PageUp', function() {
-    var focusedWindow = BrowserWindow.getFocusedWindow();
-    if (focusedWindow && focusedWindow.webContents) {
-      focusedWindow.webContents.executeJavaScript('_movePrevChannel()');
-    }
-  });
-
-  GlobalShortcut.register('Ctrl+PageDown', function() {
-    var focusedWindow = BrowserWindow.getFocusedWindow();
-    if (focusedWindow && focusedWindow.webContents) {
-      focusedWindow.webContents.executeJavaScript('_moveNextChannel()');
-    }
-  });
-
-  GlobalShortcut.register('Ctrl+Shift+PageUp', function() {
-    var focusedWindow = BrowserWindow.getFocusedWindow();
-    if (focusedWindow && focusedWindow.webContents) {
-      focusedWindow.webContents.executeJavaScript('_movePrevUnreadChannel()');
-    }
-  });
-
-  GlobalShortcut.register('Ctrl+Shift+PageDown', function() {
-    var focusedWindow = BrowserWindow.getFocusedWindow();
-    if (focusedWindow && focusedWindow.webContents) {
-      focusedWindow.webContents.executeJavaScript('_moveNextUnreadChannel()');
-    }
-  });
 }
 
 App.on('activate-with-no-open-windows', function () {

--- a/main.js
+++ b/main.js
@@ -5,6 +5,7 @@ var BrowserWindow = require('browser-window');
 var ConfigStore = require('configstore');
 var Menu = require('menu');
 var Shell = require('shell');
+var GlobalShortcut = require('electron').globalShortcut;
 
 require('crash-reporter').start();
 
@@ -387,6 +388,13 @@ function openMainWindow() {
   if (conf.get('menu-bar') === false) {
     hideMenuBar(mainWindow);
   }
+
+  var ret = GlobalShortcut.register('ctrl+p', function() {
+    var focusedWindow = BrowserWindow.getFocusedWindow();
+    if (focusedWindow && focusedWindow.webContents) {
+      focusedWindow.webContents.executeJavaScript('_openChannelPalette()');
+    }
+  });
 }
 
 App.on('activate-with-no-open-windows', function () {

--- a/main.js
+++ b/main.js
@@ -389,10 +389,38 @@ function openMainWindow() {
     hideMenuBar(mainWindow);
   }
 
-  var ret = GlobalShortcut.register('ctrl+p', function() {
+  GlobalShortcut.register('Ctrl+P', function() {
     var focusedWindow = BrowserWindow.getFocusedWindow();
     if (focusedWindow && focusedWindow.webContents) {
       focusedWindow.webContents.executeJavaScript('_openChannelPalette()');
+    }
+  });
+
+  GlobalShortcut.register('Ctrl+PageUp', function() {
+    var focusedWindow = BrowserWindow.getFocusedWindow();
+    if (focusedWindow && focusedWindow.webContents) {
+      focusedWindow.webContents.executeJavaScript('_movePrevChannel()');
+    }
+  });
+
+  GlobalShortcut.register('Ctrl+PageDown', function() {
+    var focusedWindow = BrowserWindow.getFocusedWindow();
+    if (focusedWindow && focusedWindow.webContents) {
+      focusedWindow.webContents.executeJavaScript('_moveNextChannel()');
+    }
+  });
+
+  GlobalShortcut.register('Ctrl+Shift+PageUp', function() {
+    var focusedWindow = BrowserWindow.getFocusedWindow();
+    if (focusedWindow && focusedWindow.webContents) {
+      focusedWindow.webContents.executeJavaScript('_movePrevUnreadChannel()');
+    }
+  });
+
+  GlobalShortcut.register('Ctrl+Shift+PageDown', function() {
+    var focusedWindow = BrowserWindow.getFocusedWindow();
+    if (focusedWindow && focusedWindow.webContents) {
+      focusedWindow.webContents.executeJavaScript('_moveNextUnreadChannel()');
     }
   });
 }

--- a/webframe.js
+++ b/webframe.js
@@ -51,7 +51,9 @@ var docObserver = new MutationObserver(function () {
 
     var buffersObserver = new MutationObserver(function () {
       var selected = getSelectedChannel();
-      if (selectedChannel !== selected) {
+
+      if (selectedChannel !== selected && (!selectedChannel || !selected ||
+          (selectedChannel.getAttribute("href") != selected.getAttribute("href")))) {
         oldSelectedChannel = selectedChannel;
         selectedChannel = selected;
       }

--- a/webframe.js
+++ b/webframe.js
@@ -13,5 +13,21 @@ window._zoomActualSize = function() {
 };
 
 window._openChannelPalette = function () {
-  jQuery.event.trigger({ type: 'keydown', which: 75, ctrlKey: true }); // Simulate Ctrl+K
-}
+  jQuery.event.trigger({ type: 'keydown', ctrlKey: true, which: "K".charCodeAt(0) });
+};
+
+window._movePrevChannel = function () {
+  jQuery.event.trigger({ type: 'keydown', altKey: true, which: 38 });
+};
+
+window._moveNextChannel = function () {
+  jQuery.event.trigger({ type: 'keydown', altKey: true, which: 40 });
+};
+
+window._movePrevUnreadChannel = function () {
+  jQuery.event.trigger({ type: 'keydown', altKey: true, shiftKey: true, which: 38 });
+};
+
+window._moveNextUnreadChannel = function () {
+  jQuery.event.trigger({ type: 'keydown', altKey: true, shiftKey: true, which: 40 });
+};

--- a/webframe.js
+++ b/webframe.js
@@ -11,3 +11,7 @@ window._zoomOut = function () {
 window._zoomActualSize = function() {
   webFrame.setZoomFactor(1);
 };
+
+window._openChannelPalette = function () {
+  jQuery.event.trigger({ type: 'keydown', which: 75, ctrlKey: true }); // Simulate Ctrl+K
+}

--- a/webframe.js
+++ b/webframe.js
@@ -31,3 +31,34 @@ window._movePrevUnreadChannel = function () {
 window._moveNextUnreadChannel = function () {
   jQuery.event.trigger({ type: 'keydown', altKey: true, shiftKey: true, which: 40 });
 };
+
+window._movePreviouslySelectedChannel = function () {
+  if (oldSelectedChannel !== null)
+    oldSelectedChannel.click();
+};
+
+function getSelectedChannel () {
+  return document.querySelector("#buffers .buffer.selected span[href]")
+}
+
+var selectedChannel = null;
+var oldSelectedChannel = null;
+
+var docObserver = new MutationObserver(function () {
+  var buffers = document.querySelector("#buffers");
+  if (buffers !== null) {
+    docObserver.disconnect();
+
+    var buffersObserver = new MutationObserver(function () {
+      var selected = getSelectedChannel();
+      if (selectedChannel !== selected) {
+        oldSelectedChannel = selectedChannel;
+        selectedChannel = selected;
+      }
+    });
+
+    buffersObserver.observe(buffers, { attributes: true, attributeFilter: ['class', 'href'], subtree: true });
+  }
+});
+
+docObserver.observe(document, {subtree: true, attributes: true, childList: true, attributeFilter: ['id'] });


### PR DESCRIPTION
Add an action menu to move between channels with a relative alias:
- Jump to Channel (`CommandOrControl+P`)
- Switch to Previous Channel (`CommandOrControl+PageUp`)
- Switch to Next Channel (`CommandOrControl+PageDown`)
- Switch to Previous Unread Channel (`CommandOrControl+Shift+PageUp`)
- Switch to Next Unread Channel (`CommandOrControl+Shift+PageDown`)
- Switch to Previously Selected Channel (`CommandOrControl+Tab`)
